### PR TITLE
BITCON-37: Detaching and attaching player for ad breaks

### DIFF
--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -461,19 +461,23 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
     func onAdStarted(_ event: AdStartedEvent) {
         let adPosition: AdPosition = AdEventUtil.parseAdPosition(event: event, contentDuration: player.duration)
         client.adStart(sessionKey, adStream: .ADSTREAM_SEPARATE, adPlayer: .ADPLAYER_CONTENT, adPosition: adPosition)
+        client.detachPlayer(sessionKey)
     }
 
     func onAdFinished() {
+        client.attachPlayer(sessionKey, playerStateManager: playerStateManager)
         client.adEnd(sessionKey)
     }
 
     func onAdSkipped(_ event: AdSkippedEvent) {
         customEvent(event: event)
+        client.attachPlayer(sessionKey, playerStateManager: playerStateManager)
         client.adEnd(sessionKey)
     }
 
     func onAdError(_ event: AdErrorEvent) {
         customEvent(event: event)
+        client.attachPlayer(sessionKey, playerStateManager: playerStateManager)
         client.adEnd(sessionKey)
     }
     #endif

--- a/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
+++ b/BitmovinConvivaAnalytics/Classes/ConvivaAnalytics.swift
@@ -465,19 +465,25 @@ extension ConvivaAnalytics: BitmovinPlayerListenerDelegate {
     }
 
     func onAdFinished() {
-        client.attachPlayer(sessionKey, playerStateManager: playerStateManager)
+        if !client.isPlayerAttached(sessionKey) {
+            client.attachPlayer(sessionKey, playerStateManager: playerStateManager)
+        }
         client.adEnd(sessionKey)
     }
 
     func onAdSkipped(_ event: AdSkippedEvent) {
         customEvent(event: event)
-        client.attachPlayer(sessionKey, playerStateManager: playerStateManager)
+        if !client.isPlayerAttached(sessionKey) {
+            client.attachPlayer(sessionKey, playerStateManager: playerStateManager)
+        }
         client.adEnd(sessionKey)
     }
 
     func onAdError(_ event: AdErrorEvent) {
         customEvent(event: event)
-        client.attachPlayer(sessionKey, playerStateManager: playerStateManager)
+        if !client.isPlayerAttached(sessionKey) {
+            client.attachPlayer(sessionKey, playerStateManager: playerStateManager)
+        }
         client.adEnd(sessionKey)
     }
     #endif


### PR DESCRIPTION
Following Conviva's recommended approach to detach and reattach the player on ad breaks.